### PR TITLE
Add group by statement

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -54,7 +54,13 @@ class SequelizePaginate {
         }
         return acc
       }, {})
-      const total = await Model.count(countOptions)
+
+      let total = await Model.count(countOptions)
+
+      if (options.group !== undefined) {
+        total = total.length
+      }
+
       const pages = Math.ceil(total / paginate)
       options.limit = paginate
       options.offset = paginate * (page - 1)

--- a/test/index.js
+++ b/test/index.js
@@ -88,5 +88,14 @@ describe('sequelizePaginate', () => {
       expect(docs[0].books).to.be.an('array')
       expect(docs[0].books.length).to.equal(99)
     })
+
+    it('should paginate with defaults and group by statement', async () => {
+      const group = ['id']
+      const { docs, pages, total } = await Author.paginate({ group })
+      expect(docs).to.be.an('array')
+      expect(docs.length).to.equal(25)
+      expect(pages).to.equal(4)
+      expect(total).to.equal(99)
+    })
   })
 })


### PR DESCRIPTION
A few days I find your lib and it so helps me.

When I did a query with `group by statement` the count query had return a different result that I was expected.

After that, I study the code and find an idea to solve this.

In my tests, it works OK, but feel free to test with other scenarios.

> My case is

SELECT count(*)
FROM "TABLE_A" AS "TABLE_A"
WHERE "TABLE_A"."FIELD_1" = 'XXX'
  AND "TABLE_A"."FIELD_2" = FALSE
  AND "TABLE_A"."FIELD_3" = 'SOMETHING'
  AND "TABLE_A"."FIELD_4" = 'YYY'
GROUP BY "FIELD_5", "FIELD_6"

In this case, it will return 2 rows but and it's right but in this context, I just need how much lines not grouped, so, I change the code to do this when the `group by statement` is used.

If you like it and could merge it, I appreciate it.