### PR TITLE
Add option to whitelist attribute includes in count query

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -49,7 +49,6 @@ class SequelizePaginate {
     } = {}) {
       const options = Object.assign({}, params)
       const countOptions = Object.keys(options).reduce((acc, key) => {
-          console.log('KEY', key);
         if (!['order', 'include'].includes(key)) {
           if (key === 'attributes') {
               if (options.attributes.include && keepAttrs.length > 0) {


### PR DESCRIPTION
This PR adds a "keepAttrs" option, making possible to conserve one or several attributes include in the count query.

I can be useful when your select query contains a HAVING condition based on a subquery value.
Here is my use case:

```javascript
Contenu.paginate({
    attributes: {
        include: [
            [sequelize.literal(`(
                SELECT
                    COUNT(*)
                FROM Tags t
                WHERE
                    t.nom IN (${tagsStr})
                    AND
                    t.id IN (SELECT tc.tag FROM TagsContenus tc WHERE tc.contenu = Contenu.id)
            )`), 'score'],
        ]
    },
    
    page: 1,
    paginate: 20,
    keepAttrs: ['score'],

    having: sequelize.literal('score > 0'),
    order: ['score', 'DESC']
});
```