### PR TITLE
fix(Count query): Fix count query when using nested property

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -45,9 +45,9 @@ class SequelizePaginate {
       paginate = 25,
       ...params
     } = {}) {
-      const options = Object.assign({}, params)
+      const options = { ...params }
       const countOptions = Object.keys(options).reduce((acc, key) => {
-        if (!['order', 'attributes', 'include'].includes(key)) {
+        if (!['order', 'attributes'].includes(key)) {
           // eslint-disable-next-line security/detect-object-injection
           acc[key] = options[key]
         }


### PR DESCRIPTION
Removed the include property skip for count query. It affetcs queries that uses nested properties in where clause