### PR TITLE
fix paginate method param type

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -5,10 +5,11 @@
  */
 class SequelizePaginate {
   /** @typedef {import('sequelize').Model} Model */
+  /** @typedef {typeof import('sequelize').Model} TModel */
   /**
    * Method to append paginate method to Model.
    *
-   * @param {Model} Model - Sequelize Model.
+   * @param {Model | TModel} Model - Sequelize Model.
    * @returns {*} -
    * @example
    * const sequelizePaginate = require('sequelize-paginate')

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,7 +1,9 @@
 import { FindOptions, Model } from 'sequelize'
 
+type TModel = typeof Model
+
 export class SequelizePaginate<TInstance, TAttributes> {
-  public paginate(Model: Model<TInstance, TAttributes>): void
+  public paginate (Model: Model<TInstance, TAttributes> | TModel): void
 }
 
 export interface Paginate {
@@ -10,14 +12,15 @@ export interface Paginate {
 }
 
 export interface PaginateResult<TAttributes> {
-  docs: Array<TAttributes>
+  docs: TAttributes[]
   pages: number
   total: number
 }
 
-export function paginate<TInstance, TAttributes>(
-  Model: Model<TInstance, TAttributes>
+export function paginate<TInstance, TAttributes> (
+  Model: Model<TInstance, TAttributes> | TModel
 ): void
-export function pagination<T, TAttributes>(
+
+export function pagination<T, TAttributes> (
   params: FindOptions & Paginate
 ): Promise<TAttributes>


### PR DESCRIPTION
when I call `paginate()` with a model constructor in typescript, tsc will throw a `Argument of type 'typeof User' is not assignable to parameter of type 'Model<unknown, unknown>'` compile time error.

```ts
import { Sequelize, DataTypes, Model } from 'sequelize';
import { paginate } from 'sequelize-paginate'

const sequelize = new Sequelize('sqlite::memory');

class User extends Model {}

User.init({
  firstName: {
    type: DataTypes.STRING,
    allowNull: false
  },
  lastName: {
    type: DataTypes.STRING
  }
}, {
  sequelize,
  modelName: 'User'
});

paginate(User); // compile time error
```

but seem `SequelizePaginate.paginate()` can be call with [model constructor or a model instance](https://github.com/eclass/sequelize-paginate/blob/master/src/index.js#L81) and it works in my js project. so I think the param `Model` should be type `Model<TInstance, TAttributes> | TModel`.